### PR TITLE
Vapid public key endpoint

### DIFF
--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -101,7 +101,6 @@ router.get("/current", authorize, async (req, res) => {
 router.post("/webpush", authorize, async (req, res) => {
   try {
     const { endpoint, keys } = req.body;
-    console.log(`Current Sub - endpoint: ${endpoint}, keys: ${keys}`);
 
     notificationapi.identifyUser({
       id: req.verId.toString(),

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -121,6 +121,10 @@ router.post("/webpush", authorize, async (req, res) => {
   }
 });
 
+router.get("/vap", authorize, async (req, res) => {
+  res.status(200).json({ vkey: process.env.VAPID_KEY });
+});
+
 router.delete("/delete", authorize, async (req, res) => {
   try {
     await knex("users").where({ id: req.verId }).delete();

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -101,6 +101,7 @@ router.get("/current", authorize, async (req, res) => {
 router.post("/webpush", authorize, async (req, res) => {
   try {
     const { endpoint, keys } = req.body;
+    console.log(`Current Sub - endpoint: ${endpoint}, keys: ${keys}`);
 
     notificationapi.identifyUser({
       id: req.verId.toString(),


### PR DESCRIPTION
- Add route for getting public vapid key to be used by client when subscribe() method is needed due to web push subscription being null.