### PR TITLE
Add vapid public key endpoint

### DIFF
--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -101,7 +101,6 @@ router.get("/current", authorize, async (req, res) => {
 router.post("/webpush", authorize, async (req, res) => {
   try {
     const { endpoint, keys } = req.body;
-    console.log(`Current Sub - endpoint: ${endpoint}, keys: ${keys}`);
 
     notificationapi.identifyUser({
       id: req.verId.toString(),

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -121,6 +121,10 @@ router.post("/webpush", authorize, async (req, res) => {
   }
 });
 
+router.get("/vap", authorize, async (req, res) => {
+  res.status(200).json({ vkey: process.env.VAPID_KEY });
+});
+
 router.delete("/delete", authorize, async (req, res) => {
   try {
     await knex("users").where({ id: req.verId }).delete();

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -101,6 +101,7 @@ router.get("/current", authorize, async (req, res) => {
 router.post("/webpush", authorize, async (req, res) => {
   try {
     const { endpoint, keys } = req.body;
+    console.log(`Current Sub - endpoint: ${endpoint}, keys: ${keys}`);
 
     notificationapi.identifyUser({
       id: req.verId.toString(),


### PR DESCRIPTION
- Sometimes the web push subscription retrieved by the client using the getSubscription() method is null, especially on mobile devices. To solve this, the client now calls subscribe() when getSubscription() returns a null subscription. This method requires a vapid key.
- So, I created an endpoint on the server to provide the public vapid key.